### PR TITLE
Adding proxy variables

### DIFF
--- a/tenable_io/config.py
+++ b/tenable_io/config.py
@@ -14,6 +14,9 @@ base_config = {
     'polling_interval': environ.get('TENABLEIO_POLLING_INTERVAL', '10'),
     'max_retries': environ.get('TENABLEIO_MAX_RETRIES', '3'),
     'retry_sleep_milliseconds': environ.get('TENABLEIO_RETRY_SLEEP_MILLISECONDS', '500'),
+    'http_proxy': environ.get('HTTP_PROXY', ''),
+    'https_proxy': environ.get('HTTPS_PROXY', ''),
+    'no_proxy': environ.get('NO_PROXY', ''),
 }
 
 # Read tenable_io.ini config. Default to environment variables if exist.


### PR DESCRIPTION
Adding parser variables to the base_config, allows for setting via the environment variable, otherwise defaults to blank.